### PR TITLE
Copy tree ID from gold tree when creating result

### DIFF
--- a/src/de/hhu/phil/uparse/parser/disco/DiscoParser.java
+++ b/src/de/hhu/phil/uparse/parser/disco/DiscoParser.java
@@ -350,7 +350,7 @@ public class DiscoParser {
 				}
 			} else {
 				DiscoParser.postprocess(result);
-				result.setId(treeIndex + 1);
+				result.setId(goldTree.getId());
 				try {
 					ew.writeTree(result, fw);
 				} catch (IOException e) {


### PR DESCRIPTION
The parser creates the output trees in the same order as the given gold trees, but gives them IDs according to the order and ignoring the original IDs given in the gold trees.
Here I change the behavior to copy the gold tree IDs, to ease evaluation by external tools (which will now simply be able to take the trees with the same ID and will not have to count them).
